### PR TITLE
Move to momepy.org ahead of v0.1 release

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,8 +22,8 @@ email: martin@martinfleischmann.net
 description: >-
   This is an user guide for Urban Morphology Measuring Toolkit called momepy.
 
-baseurl: /momepy-guide  # the subpath of your site, e.g. /blog. If there is no subpath for your site, use an empty string ""
-url: http://martinfleis.github.io                 # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: ""  # the subpath of your site, e.g. /blog. If there is no subpath for your site, use an empty string ""
+url: http://guide.momepy.org               # the base hostname & protocol for your site, e.g. http://example.com
 
 
 #######################################################################################
@@ -37,7 +37,7 @@ footer_text: This page was created by <a href="https://github.com/martinfleis/mo
 show_sidebar: true                # Show the sidebar. Only set to false if your only wish to host a single page.
 collapse_inactive_chapters: true  # Whether to collapse the inactive chapters in the sidebar
 textbook_logo: images/logo/logo-mm.png               # A logo to be displayed at the top of your textbook sidebar. Should be square
-textbook_logo_link: http://martinfleis.github.io/momepy-guide                    # A link for the logo.
+textbook_logo_link: http://guide.momepy.org                    # A link for the logo.
 sidebar_footer_text: momepy v0.1 <br>
     Powered by <a href="https://jupyterbook.org">Jupyter Book</a>
 number_toc_chapters: true         # Whether to add numbers to chapterse in your Table of Contents. If true, you can control this at the Chapter level in _data/toc.yml

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,4 @@ dependencies:
   - pip:
     - inequality
     - jupyter-book
-    - git+https://github.com/martinfleis/momepy.git@accessor
+    - git+https://github.com/martinfleis/momepy.git


### PR DESCRIPTION
Use master of momepy and move to guide.momepy.org instead of gh-pages branch of momepy repo.